### PR TITLE
refactor: participant metadata를 이용해 ChatUser 필드 채우도록 수정

### DIFF
--- a/src/widgets/chat/ChatUserList.tsx
+++ b/src/widgets/chat/ChatUserList.tsx
@@ -7,16 +7,15 @@ function mapParticipantToChatUser(participant: Participant): ChatUser | null {
   try {
     console.log(participant.identity);
     // 로그인 코드 완성한 후 metadata를 통해 user 구분하고 필드 채울 예정
-    // const metadata = JSON.parse(participant.metadata ?? '{}');
-    const randomNumber = Math.floor(Math.random() * 100);
+    const data = JSON.parse(participant.metadata || '{}');
     return {
-      uid: randomNumber,
-      nickname: participant.identity ?? 'Unknown',
-      profileUrl: '',
+      uid: data.uid ?? 0,
+      nickname: data.nickname ?? participant.identity,
+      profileUrl: data.profileUrl ?? '/default.png',
       sid: participant.sid,
       micOn: participant.isMicrophoneEnabled,
       camOn: participant.isCameraEnabled,
-      role: 'guest',
+      role: data.role ?? 'guest',
       isSelf: participant.isLocal,
     };
   } catch (e) {


### PR DESCRIPTION
# 📌 PR 설명

채팅 모달의 참가자 목록 기능에서, 서버와 연결되지 않았기 때문에 우선 임의로 데이터를 넣었으나 
서버와 연결되었을 때를 감안하여 participant metadata를 이용해 목록 필드를 채우도록 코드를 수정했습니다

## ✅ 작업 내용

- [ ] 기능 구현
- [ ] UI 작업
- [ ] 테스트 코드 작성
- [ ] 문서 추가
- [X] 코드 수정

## 🔗 관련 이슈 / Jira(선택)

- Closes #123 (Github 이슈)
- Jira: [Jira 이슈 번호]()

## 🧪 테스트 방법(선택)

1. 라이브키트 기반 페이지 접속
2. 방 입장 후 추가 참가자 입장시켜 보기
3. 채팅 모달에서 참가자 목록(사진, 이름, 마이크/카메라 아이콘)이 정상적으로 표시되는지 확인

## 💬 기타 사항
머지된 줄 모르고 push해서 새로운 브랜치로 만들어졌네요!! 다음부터는 머지 여부 확인하고 push 해야겠습니다
