### PR TITLE
Feature/검색 상세 페이지 구현

### DIFF
--- a/src/app/routing/config/router.ts
+++ b/src/app/routing/config/router.ts
@@ -12,6 +12,7 @@ import {
 import { roomCreateRoute } from '@/pages/room-create/route';
 import { myPageRoute } from '@/pages/my-page/route';
 import { editPageRoute } from '@/pages/edit-page/route';
+import { searchDetailRoute } from '@/pages/search-detail-page/route';
 
 const routeTree = rootRoute.addChildren([
   indexRoute,
@@ -23,6 +24,7 @@ const routeTree = rootRoute.addChildren([
   roomCreateRoute,
   myPageRoute,
   editPageRoute,
+  searchDetailRoute,
   // 여기에 다른 route 추가 가능
 ]);
 

--- a/src/pages/search-detail-page/route.ts
+++ b/src/pages/search-detail-page/route.ts
@@ -1,0 +1,9 @@
+import { createRoute } from '@tanstack/react-router';
+import { rootRoute } from '@/app/routing/__root';
+import SearchDetailPage from './ui/SearchDetailPage';
+
+export const searchDetailRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/search-detail-page',
+  component: SearchDetailPage,
+});

--- a/src/pages/search-detail-page/route.ts
+++ b/src/pages/search-detail-page/route.ts
@@ -1,9 +1,11 @@
 import { createRoute } from '@tanstack/react-router';
 import { rootRoute } from '@/app/routing/__root';
 import SearchDetailPage from './ui/SearchDetailPage';
+import { z } from 'zod';
 
 export const searchDetailRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: '/search-detail-page',
+  path: '/search-detail',
+  validateSearch: z.object({ q: z.string().min(1) }),
   component: SearchDetailPage,
 });

--- a/src/pages/search-detail-page/route.ts
+++ b/src/pages/search-detail-page/route.ts
@@ -6,6 +6,6 @@ import { z } from 'zod';
 export const searchDetailRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/search-detail',
-  validateSearch: z.object({ q: z.string().min(1) }),
+  validateSearch: z.object({ q: z.string().optional() }),
   component: SearchDetailPage,
 });

--- a/src/pages/search-detail-page/route.ts
+++ b/src/pages/search-detail-page/route.ts
@@ -1,11 +1,13 @@
 import { createRoute } from '@tanstack/react-router';
 import { rootRoute } from '@/app/routing/__root';
 import SearchDetailPage from './ui/SearchDetailPage';
-import { z } from 'zod';
 
 export const searchDetailRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/search-detail',
-  validateSearch: z.object({ q: z.string().optional() }),
+  // ✅ search 타입 선언
+  validateSearch: (search: Record<string, unknown>): { q?: string } => {
+    return { q: typeof search.q === 'string' ? search.q : undefined };
+  },
   component: SearchDetailPage,
 });

--- a/src/pages/search-detail-page/ui/SearchDetailPage.tsx
+++ b/src/pages/search-detail-page/ui/SearchDetailPage.tsx
@@ -1,22 +1,28 @@
+import { useNavigate } from '@tanstack/react-router';
 import { searchDetailRoute } from '../route';
 import StudyListContent from '@/pages/study-list/ui/StudyListContent';
 
 function SearchDetailPage() {
   // URL 쿼리에서 q 읽어오기
   const { q } = searchDetailRoute.useSearch();
+  const navigate = useNavigate();
+  const clearSearch = () =>
+    navigate({
+      to: searchDetailRoute.to,
+      search: (prev) => ({ ...prev, q: undefined }), // q 제거
+    });
 
   return (
-    <>
-      {/* 검색 결과 - 총 00개 스터디 */}
-      <div>
-        <main
-          className="mt-[55px] px-8 pb-8 pt-0 font-['Noto_Sans_KR']"
-          role="main"
-        >
-          <StudyListContent> "{q}" 검색 결과 </StudyListContent>
-        </main>
-      </div>
-    </>
+    <main
+      className="mt-[55px] px-8 pb-8 pt-0 font-['Noto_Sans_KR']"
+      role="main"
+    >
+      {/* key={q} 로 q 변경 시 컴포넌트 리셋 → useInfiniteQuery도 새로 실행 */}
+      <StudyListContent search={q} key={q} onClearSearch={clearSearch}>
+        {' '}
+        "{q}" 검색 결과{' '}
+      </StudyListContent>
+    </main>
   );
 }
 

--- a/src/pages/search-detail-page/ui/SearchDetailPage.tsx
+++ b/src/pages/search-detail-page/ui/SearchDetailPage.tsx
@@ -1,0 +1,13 @@
+function SearchDetailPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 py-10 px-6">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-4xl font-bold text-gray-900 mb-8 text-start">
+          검색 상세 페이지
+        </h1>
+      </div>
+    </div>
+  );
+}
+
+export default SearchDetailPage;

--- a/src/pages/search-detail-page/ui/SearchDetailPage.tsx
+++ b/src/pages/search-detail-page/ui/SearchDetailPage.tsx
@@ -1,12 +1,22 @@
+import { searchDetailRoute } from '../route';
+import StudyListContent from '@/pages/study-list/ui/StudyListContent';
+
 function SearchDetailPage() {
+  // URL 쿼리에서 q 읽어오기
+  const { q } = searchDetailRoute.useSearch();
+
   return (
-    <div className="min-h-screen bg-gray-50 py-10 px-6">
-      <div className="max-w-4xl mx-auto">
-        <h1 className="text-4xl font-bold text-gray-900 mb-8 text-start">
-          검색 상세 페이지
-        </h1>
+    <>
+      {/* 검색 결과 - 총 00개 스터디 */}
+      <div>
+        <main
+          className="mt-[55px] px-8 pb-8 pt-0 font-['Noto_Sans_KR']"
+          role="main"
+        >
+          <StudyListContent> "{q}" 검색 결과 </StudyListContent>
+        </main>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/src/pages/search-detail-page/ui/SearchDetailPage.tsx
+++ b/src/pages/search-detail-page/ui/SearchDetailPage.tsx
@@ -1,29 +1,40 @@
+import { useEffect } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { searchDetailRoute } from '../route';
 import StudyListContent from '@/pages/study-list/ui/StudyListContent';
+import { useSearchKeyword } from '@/shared/stores/useSearchKeyword';
 
-function SearchDetailPage() {
-  // URL 쿼리에서 q 읽어오기
+export default function SearchDetailPage() {
   const { q } = searchDetailRoute.useSearch();
   const navigate = useNavigate();
-  const clearSearch = () =>
+  const { set, clear } = useSearchKeyword();
+
+  // URL q ↔ 헤더 입력 동기화
+  useEffect(() => {
+    if (q) set(q);
+    else clear();
+  }, [q, set, clear]);
+
+  const clearSearch = () => {
+    clear(); // 검색바 비우기
     navigate({
       to: searchDetailRoute.to,
-      search: (prev) => ({ ...prev, q: undefined }), // q 제거
+      search: (prev) => ({ ...prev, q: undefined }),
+      replace: true,
     });
+  };
 
   return (
-    <main
-      className="mt-[55px] px-8 pb-8 pt-0 font-['Noto_Sans_KR']"
-      role="main"
-    >
-      {/* key={q} 로 q 변경 시 컴포넌트 리셋 → useInfiniteQuery도 새로 실행 */}
-      <StudyListContent search={q} key={q} onClearSearch={clearSearch}>
-        {' '}
-        "{q}" 검색 결과{' '}
-      </StudyListContent>
+    <main className="px-8 pb-8 pt-0 font-['Noto_Sans_KR']" role="main">
+      <div className="mt-[55px]">
+        <StudyListContent
+          key={q ?? 'all'}
+          search={q}
+          onClearSearch={clearSearch}
+        >
+          {q ? `“${q}” 검색 결과` : '전체 스터디'}
+        </StudyListContent>
+      </div>
     </main>
   );
 }
-
-export default SearchDetailPage;

--- a/src/pages/search-detail-page/ui/SearchDetailPage.tsx
+++ b/src/pages/search-detail-page/ui/SearchDetailPage.tsx
@@ -7,19 +7,19 @@ import { useSearchKeyword } from '@/shared/stores/useSearchKeyword';
 export default function SearchDetailPage() {
   const { q } = searchDetailRoute.useSearch();
   const navigate = useNavigate();
-  const { set, clear } = useSearchKeyword();
+  const { clear } = useSearchKeyword();
 
   // URL q ↔ 헤더 입력 동기화
   useEffect(() => {
-    if (q) set(q);
-    else clear();
-  }, [q, set, clear]);
+    // ✅ 전체 목록일 때만 입력칸을 비움
+    if (q === undefined) clear();
+  }, [q, clear]);
 
   const clearSearch = () => {
     clear(); // 검색바 비우기
     navigate({
       to: searchDetailRoute.to,
-      search: (prev) => ({ ...prev, q: undefined }),
+      search: {} as { q?: string },
       replace: true,
     });
   };

--- a/src/pages/study-list/route.ts
+++ b/src/pages/study-list/route.ts
@@ -5,6 +5,16 @@ import { rootRoute } from '@/app/routing/__root';
 export const studyListRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/study-list',
+  // ✅ search 타입 선언
+  validateSearch: (search: Record<string, unknown>): { q?: string } => {
+    return { q: typeof search.q === 'string' ? search.q : undefined };
+  },
+  // 핫픽스: /study-list?q=... 들어오면 검색 상세로 교정
+  beforeLoad: ({ search }) => {
+    if (search.q) {
+      throw redirect({ to: '/search-detail', search: { q: search.q } });
+    }
+  },
   component: StudyListPage,
 });
 

--- a/src/pages/study-list/ui/StudyFilters.tsx
+++ b/src/pages/study-list/ui/StudyFilters.tsx
@@ -7,6 +7,7 @@ interface StudyFiltersProps {
   onHideFullRoomsChange: (hide: boolean) => void;
   onCategoryClick: () => void;
   onReset: () => void;
+  title?: React.ReactNode;
 }
 
 export const StudyFilters = ({
@@ -16,10 +17,11 @@ export const StudyFilters = ({
   onHideFullRoomsChange,
   onCategoryClick,
   onReset,
+  title,
 }: StudyFiltersProps) => {
   return (
-    <div className="max-w-[1280px] mx-auto mt-[110px]">
-      <h1 className="text-2xl font-bold mb-[55px]">스터디 목록</h1>
+    <div className="max-w-[1280px] mx-auto">
+      {title && <h1 className="text-2xl font-bold mb-[55px]">{title}</h1>}
 
       <div className="flex justify-between items-center">
         {/* 정렬 버튼 */}

--- a/src/pages/study-list/ui/StudyListContent.tsx
+++ b/src/pages/study-list/ui/StudyListContent.tsx
@@ -7,16 +7,20 @@ import { CategoryModal } from './CategoryModal';
 import { useInfiniteStudyRoomsQuery } from '../api/useStudyRoomsQuery';
 import { useIntersectionObserver } from '@/shared/hooks/useIntersectionObserver';
 type StudyListContentProps = {
+  search?: string;
   /** 제목을 숨기고 싶으면 false */
   showHeading?: boolean;
   /** children이 없을 때 쓸 기본 제목 */
   defaultHeading?: React.ReactNode;
   children?: React.ReactNode; // 제목 슬롯
+  onClearSearch?: () => void;
 };
 export default function StudyListContent({
+  search,
   showHeading = true,
   defaultHeading = '스터디 목록',
   children,
+  onClearSearch,
 }: StudyListContentProps) {
   const [sortBy, setSortBy] = useState<'popular' | 'latest'>('latest');
   const [hideFullRooms, setHideFullRooms] = useState(false);
@@ -27,6 +31,7 @@ export default function StudyListContent({
     setSortBy('latest');
     setHideFullRooms(false);
     setSelectedCategory(null);
+    onClearSearch?.(); // ★ URL의 q 제거 → 전체 목록
   };
 
   const {
@@ -41,6 +46,7 @@ export default function StudyListContent({
     sort: sortBy,
     category: selectedCategory || undefined,
     hideFullRooms,
+    search,
   });
 
   const allStudyRooms = useMemo(() => {

--- a/src/pages/study-list/ui/StudyListContent.tsx
+++ b/src/pages/study-list/ui/StudyListContent.tsx
@@ -1,0 +1,146 @@
+//정렬/필터/목록/무한스크롤 전부 포함(유저 정보 X)
+// src/pages/study-list/ui/StudyListContent.tsx (예시 경로)
+import { useState, useMemo } from 'react';
+import { StudyCard } from './StudyCard';
+import { StudyFilters } from './StudyFilters';
+import { CategoryModal } from './CategoryModal';
+import { useInfiniteStudyRoomsQuery } from '../api/useStudyRoomsQuery';
+import { useIntersectionObserver } from '@/shared/hooks/useIntersectionObserver';
+type StudyListContentProps = {
+  /** 제목을 숨기고 싶으면 false */
+  showHeading?: boolean;
+  /** children이 없을 때 쓸 기본 제목 */
+  defaultHeading?: React.ReactNode;
+  children?: React.ReactNode; // 제목 슬롯
+};
+export default function StudyListContent({
+  showHeading = true,
+  defaultHeading = '스터디 목록',
+  children,
+}: StudyListContentProps) {
+  const [sortBy, setSortBy] = useState<'popular' | 'latest'>('latest');
+  const [hideFullRooms, setHideFullRooms] = useState(false);
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [showCategoryModal, setShowCategoryModal] = useState(false);
+
+  const handleReset = () => {
+    setSortBy('latest');
+    setHideFullRooms(false);
+    setSelectedCategory(null);
+  };
+
+  const {
+    data: studyRoomsData,
+    isLoading: isStudyRoomsLoading,
+    error: studyRoomsError,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteStudyRoomsQuery({
+    limit: 20,
+    sort: sortBy,
+    category: selectedCategory || undefined,
+    hideFullRooms,
+  });
+
+  const allStudyRooms = useMemo(() => {
+    if (!studyRoomsData?.pages) return [];
+    return studyRoomsData.pages.flatMap((page) => page.content);
+  }, [studyRoomsData]);
+
+  const { ref: loadMoreRef } = useIntersectionObserver({
+    onIntersect: () => {
+      if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+    },
+    enabled: hasNextPage && !isFetchingNextPage,
+  });
+
+  const renderStudyContent = () => {
+    if (isStudyRoomsLoading && allStudyRooms.length === 0) {
+      return (
+        <div className="col-span-full text-center py-8 text-gray-500">
+          스터디 목록을 불러오는 중...
+        </div>
+      );
+    }
+    if (studyRoomsError) {
+      return (
+        <div className="col-span-full text-center py-8 text-red-500">
+          스터디 목록을 불러오지 못했습니다.
+        </div>
+      );
+    }
+    if (allStudyRooms.length > 0) {
+      return allStudyRooms.map((room) => (
+        <StudyCard key={room.roomId} room={room} />
+      ));
+    }
+    return (
+      <div className="col-span-full text-center py-8 text-gray-500">
+        조건에 맞는 스터디가 없습니다.
+      </div>
+    );
+  };
+  const headingNode = showHeading ? (children ?? defaultHeading) : undefined;
+  return (
+    <>
+      <div className="mb-6">
+        <StudyFilters
+          sortBy={sortBy}
+          onSortChange={setSortBy}
+          hideFullRooms={hideFullRooms}
+          onHideFullRoomsChange={setHideFullRooms}
+          onCategoryClick={() => setShowCategoryModal(true)}
+          onReset={handleReset}
+          title={headingNode}
+        />
+      </div>
+
+      <section className="mt-8" aria-labelledby="available-studies">
+        <nav aria-label="스터디 방 목록">
+          <div className="max-w-[1280px] mx-auto">
+            <div
+              className="grid grid-cols-2 md:grid-cols-4 gap-x-[40px] gap-y-[55px] list-none"
+              role="list"
+            >
+              {renderStudyContent()}
+            </div>
+          </div>
+        </nav>
+
+        {allStudyRooms.length > 0 && (
+          <div className="max-w-[1280px] mx-auto mt-8">
+            {isFetchingNextPage && (
+              <div className="text-center py-8 text-gray-500">
+                <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-gray-600"></div>
+                <p className="mt-2">더 많은 스터디를 불러오는 중...</p>
+              </div>
+            )}
+
+            {hasNextPage && !isFetchingNextPage && (
+              <div ref={loadMoreRef} className="text-center py-8 text-gray-400">
+                스크롤하여 더 보기
+              </div>
+            )}
+            {/* 디버깅용 문가같다는 피드백으로 우선 주석처리 */}
+            {/* {!hasNextPage && allStudyRooms.length > 0 && (
+              <div className="text-center py-8 text-gray-400">
+                모든 스터디를 불러왔습니다.
+              </div>
+            )} */}
+          </div>
+        )}
+      </section>
+
+      <CategoryModal
+        isOpen={showCategoryModal}
+        onClose={() => setShowCategoryModal(false)}
+        selectedCategory={selectedCategory}
+        onComplete={(category) => {
+          setSelectedCategory(category);
+          setShowCategoryModal(false);
+        }}
+      />
+    </>
+  );
+}

--- a/src/pages/study-list/ui/StudyListPage.tsx
+++ b/src/pages/study-list/ui/StudyListPage.tsx
@@ -1,10 +1,22 @@
-import { Link } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
 import { useUrlAuth } from '../model';
 import { UserInfoBox } from './UserInfoBox';
 import { useUserProfileQuery, useAuth } from '@/entities/user';
 import StudyListContent from './StudyListContent';
+import { studyListRoute } from '../route';
+import { useEffect } from 'react';
+import { searchDetailRoute } from '@/pages/search-detail-page/route';
 
 export default function StudyListPage() {
+  const { q } = studyListRoute.useSearch();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (q) {
+      navigate({ to: searchDetailRoute.to, search: { q }, replace: true });
+    }
+  }, [q, navigate]);
+
   // URL에서 userId 파라미터 처리
   useUrlAuth();
 

--- a/src/pages/study-list/ui/StudyListPage.tsx
+++ b/src/pages/study-list/ui/StudyListPage.tsx
@@ -2,63 +2,14 @@ import { Link } from '@tanstack/react-router';
 import { useUrlAuth } from '../model';
 import { UserInfoBox } from './UserInfoBox';
 import { useUserProfileQuery, useAuth } from '@/entities/user';
-import { StudyCard } from './StudyCard';
-import { StudyFilters } from './StudyFilters';
-import { CategoryModal } from './CategoryModal';
-import { useInfiniteStudyRoomsQuery } from '../api/useStudyRoomsQuery';
-import { useIntersectionObserver } from '@/shared/hooks/useIntersectionObserver';
-import { useState, useMemo } from 'react';
+import StudyListContent from './StudyListContent';
 
 export default function StudyListPage() {
   // URL에서 userId 파라미터 처리
   useUrlAuth();
 
-  // 정렬/필터 상태
-  const [sortBy, setSortBy] = useState<'popular' | 'latest'>('latest');
-  const [hideFullRooms, setHideFullRooms] = useState(false);
-  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
-  const [showCategoryModal, setShowCategoryModal] = useState(false);
-
-  // 필터 초기화 함수
-  const handleReset = () => {
-    setSortBy('latest');
-    setHideFullRooms(false);
-    setSelectedCategory(null);
-  };
-
   // 인증된 사용자 ID 가져오기
   const { userId } = useAuth();
-
-  // 스터디 룸 목록 API 호출 (무한 스크롤)
-  const {
-    data: studyRoomsData,
-    isLoading: isStudyRoomsLoading,
-    error: studyRoomsError,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-  } = useInfiniteStudyRoomsQuery({
-    limit: 20,
-    sort: sortBy,
-    category: selectedCategory || undefined,
-    hideFullRooms: hideFullRooms,
-  });
-
-  // 모든 페이지의 데이터를 flat하게 합치기
-  const allStudyRooms = useMemo(() => {
-    if (!studyRoomsData?.pages) return [];
-    return studyRoomsData.pages.flatMap((page) => page.content);
-  }, [studyRoomsData]);
-
-  // 무한 스크롤을 위한 intersection observer
-  const { ref: loadMoreRef } = useIntersectionObserver({
-    onIntersect: () => {
-      if (hasNextPage && !isFetchingNextPage) {
-        fetchNextPage();
-      }
-    },
-    enabled: hasNextPage && !isFetchingNextPage,
-  });
 
   // API로 사용자 프로필 조회
   const {
@@ -66,41 +17,6 @@ export default function StudyListPage() {
     isLoading: isUserProfileLoading,
     error: userProfileError,
   } = useUserProfileQuery(userId || 0);
-
-  // 스터디 목록 렌더링 함수
-  const renderStudyContent = () => {
-    // 초기 로딩 상태
-    if (isStudyRoomsLoading && allStudyRooms.length === 0) {
-      return (
-        <div className="col-span-full text-center py-8 text-gray-500">
-          스터디 목록을 불러오는 중...
-        </div>
-      );
-    }
-
-    // 에러 상태
-    if (studyRoomsError) {
-      return (
-        <div className="col-span-full text-center py-8 text-red-500">
-          스터디 목록을 불러오지 못했습니다.
-        </div>
-      );
-    }
-
-    // 스터디 데이터가 있는 경우
-    if (allStudyRooms.length > 0) {
-      return allStudyRooms.map((room) => (
-        <StudyCard key={room.roomId} room={room} />
-      ));
-    }
-
-    // 빈 상태
-    return (
-      <div className="col-span-full text-center py-8 text-gray-500">
-        조건에 맞는 스터디가 없습니다.
-      </div>
-    );
-  };
 
   // 인증되지 않은 경우 처리
   if (!userId) {
@@ -136,73 +52,12 @@ export default function StudyListPage() {
 
   return (
     <main className="p-8 font-['Noto_Sans_KR']" role="main">
-      {/* 내정보박스 */}
       <section className="mb-8">
         <UserInfoBox userProfile={userProfileData} />
       </section>
-
-      {/* 정렬 및 필터 글자들 */}
-      <div className="mb-6">
-        <StudyFilters
-          sortBy={sortBy}
-          onSortChange={setSortBy}
-          hideFullRooms={hideFullRooms}
-          onHideFullRoomsChange={setHideFullRooms}
-          onCategoryClick={() => setShowCategoryModal(true)}
-          onReset={handleReset}
-        />
+      <div className="mt-[110px]">
+        <StudyListContent />
       </div>
-
-      <section className="mt-8" aria-labelledby="available-studies">
-        {/* <h2 id="available-studies" className="text-lg font-semibold mb-4">
-          참여 가능한 스터디
-        </h2> */}
-        <nav aria-label="스터디 방 목록">
-          <div className="max-w-[1280px] mx-auto">
-            <div
-              className="grid grid-cols-2 md:grid-cols-4 gap-x-[40px] gap-y-[55px] list-none"
-              role="list"
-            >
-              {renderStudyContent()}
-            </div>
-          </div>
-        </nav>
-
-        {/* 무한 스크롤 로딩 영역 */}
-        {allStudyRooms.length > 0 && (
-          <div className="max-w-[1280px] mx-auto mt-8">
-            {isFetchingNextPage && (
-              <div className="text-center py-8 text-gray-500">
-                <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-gray-600"></div>
-                <p className="mt-2">더 많은 스터디를 불러오는 중...</p>
-              </div>
-            )}
-
-            {hasNextPage && !isFetchingNextPage && (
-              <div ref={loadMoreRef} className="text-center py-8 text-gray-400">
-                스크롤하여 더 보기
-              </div>
-            )}
-
-            {!hasNextPage && allStudyRooms.length > 0 && (
-              <div className="text-center py-8 text-gray-400">
-                모든 스터디를 불러왔습니다.
-              </div>
-            )}
-          </div>
-        )}
-      </section>
-
-      {/* 카테고리 모달 */}
-      <CategoryModal
-        isOpen={showCategoryModal}
-        onClose={() => setShowCategoryModal(false)}
-        selectedCategory={selectedCategory}
-        onComplete={(category) => {
-          setSelectedCategory(category);
-          setShowCategoryModal(false);
-        }}
-      />
     </main>
   );
 }

--- a/src/shared/stores/useSearchKeyword.ts
+++ b/src/shared/stores/useSearchKeyword.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+type SearchKeywordStore = {
+  keyword: string;
+  set: (v: string) => void;
+  clear: () => void;
+};
+
+export const useSearchKeyword = create<SearchKeywordStore>((set) => ({
+  keyword: '',
+  set: (v) => set({ keyword: v }),
+  clear: () => set({ keyword: '' }),
+}));

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -5,14 +5,16 @@ import { useHeaderLogic } from '../model/useHeaderLogic';
 import { Logo } from './Logo';
 import { SearchBar } from './SearchBar';
 import { HeaderUserProfile } from './HeaderUserProfile';
+import { useSearchKeyword } from '@/shared/stores/useSearchKeyword';
 
 export const Header = () => {
   const { isLogin, userInfo, handleLogout } = useHeaderLogic();
+  const { clear } = useSearchKeyword();
 
   if (!isLogin) {
     return (
       <header className="flex items-center justify-between px-8 h-[5.625rem] bg-header-bg">
-        <Link to="/">
+        <Link to="/" onClick={clear}>
           <Logo />
         </Link>
         <div className="flex-1" />
@@ -32,7 +34,7 @@ export const Header = () => {
 
   return (
     <header className="flex items-center justify-between px-8 gap-6 h-[5.625rem] bg-header-bg">
-      <Link to="/study-list">
+      <Link to="/study-list" onClick={clear}>
         <Logo />
       </Link>
 

--- a/src/widgets/header/ui/SearchBar.tsx
+++ b/src/widgets/header/ui/SearchBar.tsx
@@ -1,35 +1,29 @@
 import { searchDetailRoute } from '@/pages/search-detail-page/route';
+import { useSearchKeyword } from '@/shared/stores/useSearchKeyword';
 import { useNavigate } from '@tanstack/react-router';
 import { useRef, useState } from 'react';
 
 export const SearchBar = () => {
-  const [keyword, setKeyword] = useState('');
+  // const [keyword, setKeyword] = useState('');
   const composingRef = useRef(false);
   const navigate = useNavigate();
+  const { keyword, set, clear } = useSearchKeyword();
 
-  // 실제 이동 로직
-  const goSearch = (q: string) => {
-    const query = q.trim();
-    if (!query) return; // 빈 검색어면 이동 막기
-    navigate({
-      to: searchDetailRoute.to,
-      search: { q: query },
-    });
-  };
-
-  const onSubmit = (e: React.FormEvent) => {
+  const onSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
-    const query = keyword.trim();
-    if (!query) {
+    if (composingRef.current) return;
+    const q = keyword.trim();
+    if (!q) {
+      // 현재 페이지 유지 + q만 제거(전체 목록 보기)
+      clear();
       navigate({
-        // 같은 검색 상세 페이지에서 q만 삭제
         to: searchDetailRoute.to,
         search: (prev) => ({ ...prev, q: undefined }),
         replace: true,
       });
       return;
     }
-    navigate({ to: searchDetailRoute.to, search: { q: query } });
+    navigate({ to: searchDetailRoute.to, search: { q } });
   };
 
   return (
@@ -56,7 +50,7 @@ export const SearchBar = () => {
           placeholder="나에게 맞는 스터디를 찾아보세요"
           className="flex-1 bg-transparent border-none outline-none placeholder-header-text text-[1.25rem] font-medium leading-normal font-['Noto_Sans_KR'] text-header-text text-center"
           value={keyword}
-          onChange={(e) => setKeyword(e.target.value)}
+          onChange={(e) => set(e.target.value)}
           onCompositionStart={() => (composingRef.current = true)}
           onCompositionEnd={() => (composingRef.current = false)}
           aria-label="검색어"

--- a/src/widgets/header/ui/SearchBar.tsx
+++ b/src/widgets/header/ui/SearchBar.tsx
@@ -17,10 +17,19 @@ export const SearchBar = () => {
     });
   };
 
-  const onSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
+  const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (composingRef.current) return; // 한글 IME 조합 중이면 제출 방지
-    goSearch(keyword);
+    const query = keyword.trim();
+    if (!query) {
+      navigate({
+        // 같은 검색 상세 페이지에서 q만 삭제
+        to: searchDetailRoute.to,
+        search: (prev) => ({ ...prev, q: undefined }),
+        replace: true,
+      });
+      return;
+    }
+    navigate({ to: searchDetailRoute.to, search: { q: query } });
   };
 
   return (

--- a/src/widgets/header/ui/SearchBar.tsx
+++ b/src/widgets/header/ui/SearchBar.tsx
@@ -1,6 +1,30 @@
+import { searchDetailRoute } from '@/pages/search-detail-page/route';
+import { useNavigate } from '@tanstack/react-router';
+import { useRef, useState } from 'react';
+
 export const SearchBar = () => {
+  const [keyword, setKeyword] = useState('');
+  const composingRef = useRef(false);
+  const navigate = useNavigate();
+
+  // 실제 이동 로직
+  const goSearch = (q: string) => {
+    const query = q.trim();
+    if (!query) return; // 빈 검색어면 이동 막기
+    navigate({
+      to: searchDetailRoute.to,
+      search: { q: query },
+    });
+  };
+
+  const onSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+    if (composingRef.current) return; // 한글 IME 조합 중이면 제출 방지
+    goSearch(keyword);
+  };
+
   return (
-    <div className="relative flex items-center">
+    <form onSubmit={onSubmit} className="relative flex items-center">
       <div className="flex items-center px-6 py-3 gap-4 w-[37.5rem] h-[3.125rem] rounded-[2.625rem] bg-header-button-bg shadow-[inset_-0.375rem_-0.25rem_0.9375rem_0_var(--color-header-inset-light),inset_0.25rem_0.25rem_0.9375rem_0_var(--color-header-inset-dark)]">
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -8,19 +32,27 @@ export const SearchBar = () => {
           height="1.5625rem"
           viewBox="0 0 28 25"
           fill="none"
+          aria-hidden
         >
           <path
             d="M20.0114 15.6534H18.7467L18.2985 15.2692C19.9216 13.5957 20.8137 11.4593 20.8119 9.24973C20.8119 7.42031 20.2016 5.63197 19.0582 4.11086C17.9148 2.58975 16.2896 1.40419 14.3881 0.704098C12.4867 0.00400776 10.3944 -0.179168 8.37585 0.177735C6.35729 0.534638 4.50313 1.41559 3.04784 2.70919C1.59254 4.00278 0.601468 5.65093 0.199952 7.4452C-0.201564 9.23947 0.00450873 11.0993 0.79211 12.7894C1.57971 14.4796 2.91347 15.9242 4.62472 16.9406C6.33597 17.957 8.34785 18.4995 10.4059 18.4995C12.9834 18.4995 15.3528 17.6599 17.1778 16.2653L17.6101 16.6637V17.7879L25.6146 24.8889L28 22.7686L20.0114 15.6534ZM10.4059 15.6534C6.41967 15.6534 3.20183 12.7931 3.20183 9.24973C3.20183 5.70638 6.41967 2.84607 10.4059 2.84607C14.3922 2.84607 17.6101 5.70638 17.6101 9.24973C17.6101 12.7931 14.3922 15.6534 10.4059 15.6534Z"
             fill="#8A8A8A"
           />
         </svg>
+
         <input
           type="text"
+          name="q"
           maxLength={20}
           placeholder="나에게 맞는 스터디를 찾아보세요"
           className="flex-1 bg-transparent border-none outline-none placeholder-header-text text-[1.25rem] font-medium leading-normal font-['Noto_Sans_KR'] text-header-text text-center"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          onCompositionStart={() => (composingRef.current = true)}
+          onCompositionEnd={() => (composingRef.current = false)}
+          aria-label="검색어"
         />
       </div>
-    </div>
+    </form>
   );
 };

--- a/src/widgets/header/ui/SearchBar.tsx
+++ b/src/widgets/header/ui/SearchBar.tsx
@@ -1,10 +1,9 @@
 import { searchDetailRoute } from '@/pages/search-detail-page/route';
 import { useSearchKeyword } from '@/shared/stores/useSearchKeyword';
 import { useNavigate } from '@tanstack/react-router';
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 
 export const SearchBar = () => {
-  // const [keyword, setKeyword] = useState('');
   const composingRef = useRef(false);
   const navigate = useNavigate();
   const { keyword, set, clear } = useSearchKeyword();
@@ -29,19 +28,26 @@ export const SearchBar = () => {
   return (
     <form onSubmit={onSubmit} className="relative flex items-center">
       <div className="flex items-center px-6 py-3 gap-4 w-[37.5rem] h-[3.125rem] rounded-[2.625rem] bg-header-button-bg shadow-[inset_-0.375rem_-0.25rem_0.9375rem_0_var(--color-header-inset-light),inset_0.25rem_0.25rem_0.9375rem_0_var(--color-header-inset-dark)]">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1.75rem"
-          height="1.5625rem"
-          viewBox="0 0 28 25"
-          fill="none"
-          aria-hidden
+        <button
+          type="submit"
+          aria-label="검색 실행"
+          className="shrink-0 p-0 bg-transparent border-0 cursor-pointer hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-indigo-500"
+          onMouseDown={(e) => e.preventDefault()}
         >
-          <path
-            d="M20.0114 15.6534H18.7467L18.2985 15.2692C19.9216 13.5957 20.8137 11.4593 20.8119 9.24973C20.8119 7.42031 20.2016 5.63197 19.0582 4.11086C17.9148 2.58975 16.2896 1.40419 14.3881 0.704098C12.4867 0.00400776 10.3944 -0.179168 8.37585 0.177735C6.35729 0.534638 4.50313 1.41559 3.04784 2.70919C1.59254 4.00278 0.601468 5.65093 0.199952 7.4452C-0.201564 9.23947 0.00450873 11.0993 0.79211 12.7894C1.57971 14.4796 2.91347 15.9242 4.62472 16.9406C6.33597 17.957 8.34785 18.4995 10.4059 18.4995C12.9834 18.4995 15.3528 17.6599 17.1778 16.2653L17.6101 16.6637V17.7879L25.6146 24.8889L28 22.7686L20.0114 15.6534ZM10.4059 15.6534C6.41967 15.6534 3.20183 12.7931 3.20183 9.24973C3.20183 5.70638 6.41967 2.84607 10.4059 2.84607C14.3922 2.84607 17.6101 5.70638 17.6101 9.24973C17.6101 12.7931 14.3922 15.6534 10.4059 15.6534Z"
-            fill="#8A8A8A"
-          />
-        </svg>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1.75rem"
+            height="1.5625rem"
+            viewBox="0 0 28 25"
+            fill="none"
+            aria-hidden
+          >
+            <path
+              d="M20.0114 15.6534H18.7467L18.2985 15.2692C19.9216 13.5957 20.8137 11.4593 20.8119 9.24973C20.8119 7.42031 20.2016 5.63197 19.0582 4.11086C17.9148 2.58975 16.2896 1.40419 14.3881 0.704098C12.4867 0.00400776 10.3944 -0.179168 8.37585 0.177735C6.35729 0.534638 4.50313 1.41559 3.04784 2.70919C1.59254 4.00278 0.601468 5.65093 0.199952 7.4452C-0.201564 9.23947 0.00450873 11.0993 0.79211 12.7894C1.57971 14.4796 2.91347 15.9242 4.62472 16.9406C6.33597 17.957 8.34785 18.4995 10.4059 18.4995C12.9834 18.4995 15.3528 17.6599 17.1778 16.2653L17.6101 16.6637V17.7879L25.6146 24.8889L28 22.7686L20.0114 15.6534ZM10.4059 15.6534C6.41967 15.6534 3.20183 12.7931 3.20183 9.24973C3.20183 5.70638 6.41967 2.84607 10.4059 2.84607C14.3922 2.84607 17.6101 5.70638 17.6101 9.24973C17.6101 12.7931 14.3922 15.6534 10.4059 15.6534Z"
+              fill="#8A8A8A"
+            />
+          </svg>
+        </button>
 
         <input
           type="text"


### PR DESCRIPTION
# 📌 PR 설명

검색 상세 페이지를 구현했습니다

## ✅ 작업 내용

- [x] 기능 구현
- [x] UI 작업
- [ ] 테스트 코드 작성
- [ ] 문서 추가

## 🔗 관련 이슈 / Jira(선택)

- Closes #123 (Github 이슈)
- Jira: [Jira 이슈 번호]()

## 🧪 테스트 방법(선택)
<img width="1894" height="866" alt="image" src="https://github.com/user-attachments/assets/b94b5c44-4f84-4d03-995b-736ee8df0a5b" />
<img width="1896" height="862" alt="image" src="https://github.com/user-attachments/assets/860ee202-b077-4ec5-af3c-005ebd92560a" />


## 💬 기타 사항
study-list 페이지에서 헤더에 검색어를 입력했을 때 study-list?q=검색어 로 url이 튀고 api 호출도 가지 않는 문제가 가끔 일어나서,
우선 hotfix로 라우팅레벨에서 q (검색어)가 들어오면 무조건 /search-detail-page?q=...로 redirect하게 만들어놨습니다. 
동작에는 문제 없으니 원인은 추후에 확인해보겠습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Search Results page and a reusable StudyListContent component for listing/filtering studies.
  - Introduced a global search keyword store.

- Improvements
  - Search bar now fully controlled, submits to the search page, syncs with URL, and supports history-friendly clearing.
  - Header links clear active search on navigation.
  - Legacy /studyList redirects to /study-list.

- Refactor
  - Study List page simplified to delegate to the new content component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->