### PR TITLE
Fix/룸 삭제 목록 동기화, 기본 이미지 선언

### DIFF
--- a/src/entities/room/api/queries.ts
+++ b/src/entities/room/api/queries.ts
@@ -6,6 +6,7 @@ import { leaveRoom } from './leaveRoom';
 import { deleteRoom } from './deleteRoom';
 import { useRoomTokenStore } from '../model/useRoomTokenStore';
 import { roomQueryKeys } from './queryKeys';
+import { useRoomStateStore } from '@/features/room';
 
 // Room 상세 조회
 export const useRoomInfoQuery = (roomId: number) => {
@@ -68,25 +69,29 @@ export const useRejoinRoomMutation = () => {
 
 export const useLeaveRoomMutation = () => {
   const { clearToken } = useRoomTokenStore();
+  const { setIntentionalExit } = useRoomStateStore();
 
   return useMutation({
     mutationFn: ({ roomId, userId }: { roomId: number; userId: number }) =>
       leaveRoom(roomId, userId),
     onSuccess: (_, variables) => {
-      // 방 나가기 성공 시 토큰 삭제
+      // 방 나가기 성공 시 토큰 삭제 및 의도적 나가기 플래그 설정
       clearToken(variables.roomId);
+      setIntentionalExit(variables.roomId, true);
     },
   });
 };
 
 export const useDeleteRoomMutation = () => {
   const { clearToken } = useRoomTokenStore();
+  const { setIntentionalExit } = useRoomStateStore();
 
   return useMutation({
     mutationFn: ({ roomId, userId }: { roomId: number; userId: number }) =>
       deleteRoom(roomId, userId),
     onSuccess: (_, variables) => {
       clearToken(variables.roomId);
+      setIntentionalExit(variables.roomId, true);
     },
   });
 };

--- a/src/entities/user/api/recentStudy.ts
+++ b/src/entities/user/api/recentStudy.ts
@@ -1,5 +1,6 @@
 import { request, REQUEST_METHOD } from '@/shared/api/request';
 import type { RecentStudyResponse, RecentStudyRoom } from '@/entities/study';
+import { DEFAULT_PROFILE_IMG } from '@/shared/constants';
 
 interface RawRecentStudyRoom {
   roomId: number;
@@ -35,7 +36,7 @@ const adaptRecentStudyData = (
               .map((t) => t.trim())
               .filter((t) => t.length > 0)
           : [],
-        thumbnailUrl: room.thumbnailUrl,
+        thumbnailUrl: room.thumbnailUrl || DEFAULT_PROFILE_IMG,
         isDelete: room.isDelete,
       }),
     ),

--- a/src/features/profile-card/ui/ProfileCard.tsx
+++ b/src/features/profile-card/ui/ProfileCard.tsx
@@ -3,8 +3,7 @@ import MarshmallowHeatmap, { type StudyPoint } from './MarshmallowHeatmap';
 import { useUserInfo } from '@/entities/user/model/useUserInfo';
 import { request } from '@/shared/api/request';
 import { useRouter } from '@tanstack/react-router';
-
-const DEFAULT_PROFILE_IMG = '/images/profile_apple.jpg';
+import { DEFAULT_PROFILE_IMG } from '@/shared/constants';
 
 // 스낵 타입 정의
 type SnackType = 'O' | 'RE';

--- a/src/features/room-create/model/useRoomCreateForm.ts
+++ b/src/features/room-create/model/useRoomCreateForm.ts
@@ -160,11 +160,14 @@ export const useRoomCreateForm = () => {
         return;
       }
 
+      const formValues = form.getValues();
+
       joinRoomMutation.mutate(
         {
           roomId: data.roomId,
           userId,
           identity: userInfo.nickname,
+          password: formValues.isPrivate ? formValues.password : undefined,
         },
         {
           onSuccess: () => {

--- a/src/pages/edit-page/ui/EditPage.tsx
+++ b/src/pages/edit-page/ui/EditPage.tsx
@@ -53,7 +53,7 @@ function EditPage() {
         setPreviewUrl(userInfo.profileUrl);
       }
     }
-  }, [userInfo, previewUrl, nickname]);
+  }, [userInfo, previewUrl]);
 
   // 이미지 디코딩 검증 함수
   const canDecodeImageFromFile = async (file: File): Promise<boolean> => {

--- a/src/pages/edit-page/ui/EditPage.tsx
+++ b/src/pages/edit-page/ui/EditPage.tsx
@@ -5,6 +5,7 @@ import {
   createDirectCroppedBlob,
   loadImageFromBlob,
 } from '@/features/focus-capture/model/imageResize';
+import { DEFAULT_PROFILE_IMG } from '@/shared/constants';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { Trash2 } from 'lucide-react';
@@ -18,8 +19,6 @@ const ACCEPTED_IMAGE_TYPES = [
   'image/png',
   'image/webp',
 ];
-
-const DEFAULT_PROFILE_IMG = '/images/profile_apple.jpg';
 
 const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
 const PROFILE_WIDTH = 40;

--- a/src/pages/room/ui/RoomPage.tsx
+++ b/src/pages/room/ui/RoomPage.tsx
@@ -45,9 +45,9 @@ function RoomPage() {
   const resetStopwatch = useStopwatchStore((state) => state.resetStopwatch);
   const updateServerData = useStopwatchStore((state) => state.updateServerData);
   const { setOwner, setRoomSettings } = usePomodoroStore();
-  const { isIntentionalExit, clearIntentionalExit } = useRoomStateStore();
   const [retryCount, setRetryCount] = useState<number>(0);
 
+  const { isIntentionalExit, clearIntentionalExit } = useRoomStateStore();
   // 저장된 미디어 설정 로드
   const [mediaSettings] = useState(() => loadMediaSettings());
 
@@ -152,7 +152,6 @@ function RoomPage() {
           console.error('자동 재입장 실패:', error);
           setAutoRejoinStatus('failed');
           setErrorMessage('방에 재입장할 수 없습니다.');
-
           navigate({
             to: '/room/$roomId/prejoin',
             params: { roomId },
@@ -224,18 +223,13 @@ function RoomPage() {
 
     // 의도적 나가기인 경우 즉시 study-list로 이동
     if (isIntentionalExit(roomIdNumber)) {
-      clearIntentionalExit(roomIdNumber);
       navigate({ to: '/study-list' });
+      clearIntentionalExit(roomIdNumber);
       return;
     }
 
-    // 토큰이 없는 경우 자동 재입장 시도
-    if (
-      !token &&
-      autoRejoinStatus === 'idle' &&
-      userId &&
-      !isIntentionalExit(roomIdNumber)
-    ) {
+    // 토큰이 없는 경우 자동 재입장 시도 (의도적 나가기가 아닌 경우에만)
+    if (!token && autoRejoinStatus === 'idle' && userId) {
       attemptAutoRejoin();
       return;
     }

--- a/src/pages/study-list/model/useUserSettings.ts
+++ b/src/pages/study-list/model/useUserSettings.ts
@@ -75,10 +75,10 @@ export const useUserSettings = ({ userProfile }: UseUserSettingsProps) => {
   const convertToApiData = () => {
     const totalStudyTime = parseInt(targetHour) * 60 + parseInt(targetMinute);
     return {
-      goalStudyTime: totalStudyTime ?? null,
-      determination: determination.trim() ?? null,
-      targetDate: formatDateForServer(selectedDate!) ?? null,
-      targetDateTitle: targetDateTitle.trim() ?? null,
+      goalStudyTime: totalStudyTime,
+      determination: determination.trim() || undefined,
+      targetDate: selectedDate ? formatDateForServer(selectedDate) : undefined,
+      targetDateTitle: targetDateTitle.trim() || undefined,
     };
   };
 

--- a/src/pages/study-list/ui/StudyCard.tsx
+++ b/src/pages/study-list/ui/StudyCard.tsx
@@ -3,6 +3,7 @@ import type { StudyRoom } from '@/entities/study';
 import { UserIcon, LockIcon, ClockIcon } from '@/shared/ui/icons';
 import { Button } from '@/shared/ui';
 import { StudyModal } from './StudyModal';
+import { DEFAULT_PROFILE_IMG } from '@/shared/constants';
 
 interface StudyCardProps {
   room: StudyRoom;
@@ -23,7 +24,7 @@ export function StudyCard({ room }: StudyCardProps) {
         {/* 썸네일 섹션 */}
         <div className="relative mt-[11px] mx-[10px]">
           <img
-            src={room.thumbnail || '/study-thumbnail.png'}
+            src={room.thumbnail || DEFAULT_PROFILE_IMG}
             alt={`${room.title} 썸네일`}
             className="w-full h-[160px] object-cover rounded-[30px]"
           />

--- a/src/shared/config/index.ts
+++ b/src/shared/config/index.ts
@@ -1,0 +1,1 @@
+export * from './livekit';

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_PROFILE_IMG = '/images/profile_apple.jpg';

--- a/src/shared/ui/sonner.tsx
+++ b/src/shared/ui/sonner.tsx
@@ -5,6 +5,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme="system"
       className="toaster group"
+      position="top-center"
       style={
         {
           '--normal-bg': 'var(--popover)',

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -6,8 +6,7 @@ import { Logo } from './Logo';
 import { SearchBar } from './SearchBar';
 import { HeaderUserProfile } from './HeaderUserProfile';
 import { useSearchKeyword } from '@/shared/stores/useSearchKeyword';
-
-const DEFAULT_PROFILE_IMG = '/images/profile_apple.jpg';
+import { DEFAULT_PROFILE_IMG } from '@/shared/constants';
 
 export const Header = () => {
   const { isLogin, userInfo, handleLogout } = useHeaderLogic();

--- a/src/widgets/media-toolbar/ui/MediaToolbar.tsx
+++ b/src/widgets/media-toolbar/ui/MediaToolbar.tsx
@@ -7,7 +7,6 @@ import {
 } from '@/entities/room/api/queries';
 import { useAuth } from '@/entities/user';
 import { useFaceDetectionStore } from '@/features/face-detection';
-import { useRoomStateStore } from '@/features/room';
 import { Button } from '@/shared/ui';
 import RoomMediaControls from './RoomMediaControls';
 import { getMediaButtonStyle } from './styles';
@@ -33,7 +32,6 @@ function MediaToolbar({
 
   const { isFaceDetectionEnabled, setFaceDetectionEnabled } =
     useFaceDetectionStore();
-  const { setIntentionalExit } = useRoomStateStore();
 
   const roomIdNumber = parseInt(roomId, 10);
 
@@ -44,7 +42,6 @@ function MediaToolbar({
     }
     queryClient.invalidateQueries({ queryKey: ['study-rooms'] });
 
-    setIntentionalExit(roomIdNumber, true);
     if (isOwner) {
       deleteRoomMutation.mutate(
         { roomId: roomIdNumber, userId },
@@ -55,7 +52,6 @@ function MediaToolbar({
           onError: (error) => {
             console.error('방 삭제 실패:', error);
             alert('방 삭제에 실패했습니다.');
-            setIntentionalExit(roomIdNumber, false);
           },
         },
       );
@@ -71,7 +67,6 @@ function MediaToolbar({
         onError: (error) => {
           console.error('방 나가기 실패:', error);
           alert('방 나가기에 실패했습니다.');
-          setIntentionalExit(roomIdNumber, false);
         },
       },
     );


### PR DESCRIPTION
# 📌 PR 설명

- 룸 삭제시 목록 동기화
- 기본 이미지 선언
- 날짜 미입력 시 폼 에러 제거
- sonner 위치 변경

## ✅ 작업 내용

- [x] 기능 구현
- [ ] UI 작업
- [ ] 테스트 코드 작성
- [ ] 문서 추가

## 🔗 관련 이슈 / Jira(선택)

- Closes #123 (Github 이슈)
- Jira: [Jira 이슈 번호]()

## 🧪 테스트 방법(선택)

1. 페이지 접속
2. 버튼 클릭
3. 결과 확인

## 💬 기타 사항

1. 리뷰어에게 참고가 될만한 정보나 추가 설명 부탁드립니다.
2. 사용하지 않는 메뉴는 삭제해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents broken images by using a default profile/thumbnail across profile, study list, and cards.
  - Joins newly created private rooms using the password only when required.
  - Improves room leave/delete flow with more reliable redirects and auto-rejoin behavior.

- Style
  - Toast notifications now appear at the top-center by default (custom positions still supported).

- Refactor
  - Centralized default image handling and streamlined configuration exports for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->