### PR TITLE
Fix 스터디카드 태그 위치 고정

### DIFF
--- a/src/pages/study-list/ui/StudyCard.tsx
+++ b/src/pages/study-list/ui/StudyCard.tsx
@@ -58,7 +58,7 @@ export function StudyCard({ room }: StudyCardProps) {
             </div>
 
             {/* 태그 */}
-            <div className="flex flex-wrap gap-2">
+            <div className="flex flex-wrap gap-2 h-[15px] overflow-hidden">
               {room.tags.slice(0, 3).map((tag, index) => (
                 <span
                   key={index}


### PR DESCRIPTION
# 📌 PR 설명

- 태그 유무에 따라 스터디 카드 내 버튼위치가 움직이는 문제가 있어 태그 위치를 고정 시켰습니다.

## ✅ 작업 내용

- [ ] 기능 구현
- [ ] UI 작업
- [ ] 테스트 코드 작성
- [ ] 문서 추가

## 🔗 관련 이슈 / Jira(선택)

- Closes #123 (Github 이슈)
- Jira: [Jira 이슈 번호]()

## 🧪 테스트 방법(선택)

1. 페이지 접속
2. 버튼 클릭
3. 결과 확인

## 💬 기타 사항

1. 리뷰어에게 참고가 될만한 정보나 추가 설명 부탁드립니다.
2. 사용하지 않는 메뉴는 삭제해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated Study Card tag display to a fixed single-line height with overflow clipped for a cleaner layout.
  - Prevents tag wrapping and visual overflow; only tags that fit are shown.
  - The “+N” more-tags indicator may not appear if it doesn’t fit within the height constraint.
  - Improves visual consistency of study lists, especially in dense layouts and smaller viewports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->